### PR TITLE
Changed how configuration #includes are processed

### DIFF
--- a/src/core/admincmd.c
+++ b/src/core/admincmd.c
@@ -493,8 +493,6 @@ local void Ccd(const char *tc, const char *params, Player *p, const Target *targ
 
 	if (!is_valid_path(params))
 		chat->SendMessage(p, "Invalid path");
-	else if (!can_access_path(p, params))
-		chat->SendMessage(p, "Access denied");
 	else if (stat(params, &st) < 0)
 		chat->SendMessage(p, "The specified path doesn't exist");
 	else if (!S_ISDIR(st.st_mode))

--- a/src/include/app.h
+++ b/src/include/app.h
@@ -6,8 +6,7 @@
 
 typedef struct APPContext APPContext;
 
-typedef int (*APPFileFinderFunc)(char *dest, int destlen,
-		const char *arena, const char *name);
+typedef int (*APPFileFinderFunc)(char *dest, int destlen, const char *arena, const char *name, const char *searchpath);
 typedef void (*APPReportErrFunc)(const char *error);
 
 

--- a/src/include/param.h
+++ b/src/include/param.h
@@ -5,8 +5,7 @@
 /* pyconst: config, "CFG_*" */
 
 /* the search path for config files */
-#define CFG_CONFIG_SEARCH_PATH "arenas/%b/%n:conf/%n:%n:arenas/(default)/%n"
-
+#define CFG_CONFIG_SEARCH_PATH "arenas/%b/%n:arenas/(default)/%n:conf/%n:%n"
 
 /* the search path for map files */
 #define CFG_LVL_SEARCH_PATH "arenas/%b/%m:maps/%m:%m:arenas/%b/%b.lvl:maps/%b.lvl:arenas/(default)/%m"

--- a/src/include/pathutil.h
+++ b/src/include/pathutil.h
@@ -83,5 +83,24 @@ int is_valid_path(const char *path);
  */
 const char *get_basename(const char *path);
 
+
+/**
+ * Normalizes the given path by ensuring it is an absolute path without any relative directory
+ * references. This function operates like realpath, except it will not resolve links.
+ *
+ * @param *path
+ *	The path to normalize
+ *
+ * @param *out
+ *	A pointer to a string to receive the normalized path
+ *
+ * @param out_len
+ *	The size of the output buffer
+ *
+ * @return
+ *	True if the path is normalized and output successfully; false otherwise.
+ */
+int normalize_path(const char *path, char *out, size_t out_len);
+
 #endif
 

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -95,7 +95,7 @@ no_bin:
 }
 
 
-local int finder(char *dest, int destlen, const char *ar, const char *name)
+local int finder(char *dest, int destlen, const char *ar, const char *name, const char *searchpath)
 {
 	astrncpy(dest, name, destlen);
 	return 0;


### PR DESCRIPTION
- Config files which #include another file can now only include files
  from the current file's directory or children directories
- #include search paths have changed slightly; when including a file
  from a config file, the current directory is searched, then the
  current arena's directory, then the default arena's directory,
  then /conf, then the ASSS root
