### PR TITLE
Time-based rewards

### DIFF
--- a/src/hs_py/hs_fg_wz.py
+++ b/src/hs_py/hs_fg_wz.py
@@ -201,7 +201,7 @@ class WZSets:
     # Sets the minimum number of players required on each team (specified by Team:PrivFreqStart and
     # Team:MaxFrequency) to allow flags to be owned. If set and not met, all flags will be placed
     # as neutral flags.
-    me.minplayersperteam = 0 #cfg.GetInt(c, "Flag", "MinPlayersPerTeam", 2)
+    me.minplayersperteam = cfg.GetInt(c, "Flag", "MinPlayersPerTeam", 2)
 
 
 # useful flag things

--- a/src/hs_py/hs_fg_wz.py
+++ b/src/hs_py/hs_fg_wz.py
@@ -201,7 +201,7 @@ class WZSets:
     # Sets the minimum number of players required on each team (specified by Team:PrivFreqStart and
     # Team:MaxFrequency) to allow flags to be owned. If set and not met, all flags will be placed
     # as neutral flags.
-    me.minplayersperteam = cfg.GetInt(c, "Flag", "MinPlayersPerTeam", 2)
+    me.minplayersperteam = 0 #cfg.GetInt(c, "Flag", "MinPlayersPerTeam", 2)
 
 
 # useful flag things

--- a/src/hscore/hscore_rewards.c
+++ b/src/hscore/hscore_rewards.c
@@ -485,7 +485,7 @@ local void flagWinCallback(Arena *arena, int freq, int *pts)
 
 				double time_fraction = 1;
 				if (playtime)
-					time_fraction = HSCR_MIN(*playtime * (*playtime * 0.05) / max_playtime, 1);
+					time_fraction = HSCR_MIN(*playtime * 1.3 / max_playtime, 1);
 
 				if (i->p_freq == freq) {
 					int exp_reward = adata->max_flag_exp;

--- a/src/hscore/hscore_rewards.c
+++ b/src/hscore/hscore_rewards.c
@@ -94,7 +94,7 @@ local inline int flagging_freq(Arena *arena, int freq)
 {
 	int priv_freq_start = cfg->GetInt(arena->cfg, "Team", "PrivFreqStart", 100);
 	int max_freq = cfg->GetInt(arena->cfg, "Team", "MaxFrequency", (priv_freq_start + 2));
-	return freq >= priv_freq_start && freq < max_freq;
+	return freq >= priv_freq_start && freq < max_freq || (freq == 90 || freq == 91);
 }
 
 local void end_playtime(Player *p)
@@ -466,7 +466,7 @@ local void flagWinCallback(Arena *arena, int freq, int *pts)
 
 				double time_fraction = 1;
 				if (playtime)
-					time_fraction = HSCR_MIN(*playtime * (*playtime * 0.25) / max_playtime, 1);
+					time_fraction = HSCR_MIN(*playtime * (*playtime * 0.15) / max_playtime, 1);
 
 				if (i->p_freq == freq) {
 					int exp_reward = adata->max_flag_exp;


### PR DESCRIPTION
Players can no longer join a flag game right before it ends and receive the full reward. Their rewards are instead scaled according to their time played on a flagging frequency.
